### PR TITLE
Correction

### DIFF
--- a/49. descifra la frase/descripcion.md
+++ b/49. descifra la frase/descripcion.md
@@ -4,6 +4,6 @@ Escribe una función descifrar que reciba un string y un objeto. Utiliza las pro
 
 ```javascript
 descifrar("h0l4", { 0: "o", 4: "a" }); // "hola"
-descifrar("pyrmizo", { y: "e", z: s }); // "permiso"
+descifrar("pyrmizo", { y: "e", z: "s" }); // "permiso"
 descifrar("igual", { h: "n" }); // "igual"
 ```


### PR DESCRIPTION
descifrar("pyrmizo", { y: "e", z: s }); // "permiso" / the quotes are missing in the s value